### PR TITLE
Add permission checks for upload pages

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2421,12 +2421,12 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@clerk/clerk-react": {
-      "version": "4.28.3",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-4.28.3.tgz",
-      "integrity": "sha512-keiQSpl9EVP7XNKOLXRs+zxkrGG8FRueMdn0+GcOUlmfIUcE9HFhCX/2wCt7OiLuuZLJpMOVEg9weDepW5APEg==",
+      "version": "4.30.7",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-4.30.7.tgz",
+      "integrity": "sha512-+6Q1hVteqn66gFLiCKSqqSdz2MBjsEjs1fkGLAEKZC1GdfOKrH6oWcLuSwUdyqRvJWuyjeIgwq15zoHtXKyztA==",
       "dependencies": {
-        "@clerk/shared": "1.1.1",
-        "@clerk/types": "3.58.1",
+        "@clerk/shared": "1.3.3",
+        "@clerk/types": "3.62.1",
         "tslib": "2.4.1"
       },
       "engines": {
@@ -2442,9 +2442,9 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/@clerk/shared": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-1.1.1.tgz",
-      "integrity": "sha512-pEzhalD1Yo/gGsOE2BQugVQTjlIl2aYmoeRld3BDXHRDV1jnk+yUE2CFOw6bojgFWN9sbeN/ph/47UWvvoCSOg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-1.3.3.tgz",
+      "integrity": "sha512-Eein8cK72dlvY6Q1uFuw9K9MJH1OPjU8FzWloMTKklBo+iPiM6+uENGeGwlY5KId3q/kgPwRc2hBQnUoaijxCQ==",
       "dependencies": {
         "glob-to-regexp": "0.4.1",
         "js-cookie": "3.0.1",
@@ -2460,9 +2460,9 @@
       }
     },
     "node_modules/@clerk/types": {
-      "version": "3.58.1",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-3.58.1.tgz",
-      "integrity": "sha512-cumryWXAYNCApsc3pmuHiJQnhUcNuQPCMI8w/bVU9VuGm9Ry0zhCWawD7F3/VWAOnAPu4ghKrwEaLkGsiSsY2Q==",
+      "version": "3.62.1",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-3.62.1.tgz",
+      "integrity": "sha512-RmQhWB7EMZw2nE24viQG79VyEUULZYWndYew5oXiZx06DyvysMNCorDyEGRmgBbprv7bnbYhHdOtKmx8Wj0jug==",
       "dependencies": {
         "csstype": "3.1.1"
       },

--- a/frontend/src/pages/UploadPage/CSVUploadPage.tsx
+++ b/frontend/src/pages/UploadPage/CSVUploadPage.tsx
@@ -7,7 +7,7 @@ import { DataGrid } from "@mui/x-data-grid";
 import "./CSVUploadPage.css";
 import { UploadContext } from "../../contexts/upload_context";
 import { Uploads } from "../../__generated__/graphql";
-import { useOrganization, useUser } from "@clerk/clerk-react";
+import { useOrganization, useUser, useAuth } from "@clerk/clerk-react";
 
 // Define a type for the file with progress information
 type UploadedFile = {
@@ -31,6 +31,9 @@ const CSVUploadBox = () => {
 	const [uploads, setUpload] = useState<Uploads[]>([]);
 	const { user, isSignedIn } = useUser();
 	const { organization } = useOrganization();
+	//permission check for uploading CSVs
+	const {has} = useAuth();
+	const canManageSettings = has ? has({ permission: "org:test:limit" }) : false;
 
 	useEffect(() => {
 		if (isSignedIn && user) {
@@ -310,6 +313,19 @@ const CSVUploadBox = () => {
 		}
 		// need some logic to handle file history
 	};
+	//If the user is does not have access to the upload page
+	if (!canManageSettings) { 
+		return (
+		<div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', height: '70vh' }}>
+			<div style={{ textAlign: 'center' }}>
+			  <div>You do not have permission to access this page.</div>
+			</div>
+			<div style={{ textAlign: 'center' }}>
+			  <div>Please contact the administrator.</div>
+			</div>
+		</div>
+		);
+	}
 
 	return (
 		<div>

--- a/frontend/src/pages/UploadPage/RSSUploadPage.tsx
+++ b/frontend/src/pages/UploadPage/RSSUploadPage.tsx
@@ -8,12 +8,15 @@ import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
 import "./RSSUploadPage.css";
 import { UploadContext } from "../../contexts/upload_context";
-import { useUser, useOrganization } from "@clerk/clerk-react";
+import { useUser, useOrganization, useAuth } from "@clerk/clerk-react";
 
 const RSSUploadBox = () => {
 	const { addRssFeed } = React.useContext(UploadContext)!;
 	const { user, isSignedIn } = useUser();
 	const { organization } = useOrganization();
+	//permission check for uploading RSS
+	const {has} = useAuth();
+	const canManageSettings = has ? has({ permission: "org:test:limit" }) : false;
 
 	// click CSV button -> CSV page
 	let navigate = useNavigate();
@@ -215,6 +218,19 @@ const RSSUploadBox = () => {
 				}
 			}
 		}
+	}
+	//If the user is does not have access to the upload page
+	if (!canManageSettings) { 
+		return (
+		<div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', height: '70vh' }}>
+			<div style={{ textAlign: 'center' }}>
+			  <div>You do not have permission to access this page.</div>
+			</div>
+			<div style={{ textAlign: 'center' }}>
+			  <div>Please contact the administrator.</div>
+			</div>
+		</div>
+		);
 	}
 
 	return (


### PR DESCRIPTION
I created a permission in Clerk, org:test:limit, that grants users access to the upload page for both CSV and RSS uploading. 
If a user lacks this permission, they receive a message on the upload page stating, "You do not have permission to access this page. Please contact the administrator." This ensures that only authorized users can access the upload page.