### PR TITLE
Clerk middleware for resolvers working

### DIFF
--- a/backend/authMiddleware.ts
+++ b/backend/authMiddleware.ts
@@ -34,8 +34,8 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction) 
       throw error;
     }
 
-    // Decode the org token without verifying it
-    const decodedOrgToken: any = jwt.decode(orgToken);
+    // Decode the org token 
+    const decodedOrgToken: any = jwt.decode(typeof orgToken === 'string' ? orgToken : orgToken[0]);
     if (!decodedOrgToken) {
       const error = new Error("Forbidden");
       (error as any).code = 403;
@@ -43,7 +43,7 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction) 
     }
 
     // Check if the user is part of the required organization
-    const userOrgs = decodedOrgToken.orgs; // Assuming `orgs` contains the user's organization IDs
+    const userOrgs = decodedOrgToken.orgs; 
     const allowedOrgs = ["org_2bHDzl2Zax0nILIzDhui2DLWdH6", "org_2ZN4MA41LAA9l4j0rZBC5Olsr3Y"];
     if (!allowedOrgs.includes(userOrgs)) {
       const error = new Error("Forbidden: Not part of the organization");

--- a/backend/graphql/resolvers/graphql_resolvers.ts
+++ b/backend/graphql/resolvers/graphql_resolvers.ts
@@ -1,441 +1,238 @@
+
 import {
-	INeighborhoods,
-	TractsByNeighborhoodArgs,
-	ITracts,
-	IArticles,
+  INeighborhoods,
+  TractsByNeighborhoodArgs,
+  ITracts,
+  IArticles,
   ILocations,
-	DemographicsByTractsArgs,
+  DemographicsByTractsArgs,
 } from "../types/types";
 import { Collection } from "mongodb";
-import { authMiddleware } from "../../authMiddleware.js";
+import { clerkMiddleware } from '@clerk/express';
+import express from 'express';
+import { ApolloServer } from 'apollo-server-express';
+import { typeDefs } from '../schemas/type_definitions'; 
+import { debug } from "console";
 
-// helper function to check if a string is a number
-function isNumber(str: any) {
-	return !isNaN(str);
+const app = express();
+
+//made global middleware for clerk
+app.use(clerkMiddleware());
+
+// Helper function to decode JWT from headers
+function getUserFromHeaders(req: any) {
+  const userHeader = req.headers.user;
+  if (!userHeader) {
+    throw new Error('Unauthorized');
+  }
+  const decodedToken = JSON.parse(userHeader as string);
+  if (!decodedToken) {
+    throw new Error('Unauthorized');
+  }
+  return decodedToken;
 }
 
+// Helper function to check if a string is a number
+function isNumber(str: any): boolean {
+  return !isNaN(str);
+}
+
+// Set up Apollo Server for GraphQL
+async function startServer() {
+  const server = new ApolloServer({
+    typeDefs,  
+    resolvers, 
+    context: ({ req }) => ({ req }), // Pass the request object to resolvers
+  });
+
+  await server.start();
+  server.applyMiddleware({ app });
+
+  // Start Express server
+  const PORT = process.env.PORT || 4000;
+  app.listen(PORT, () => {
+    console.log(`Server is running on http://localhost:${PORT}${server.graphqlPath}`);
+  });
+}
+
+startServer();
+
 export const resolvers = {
-	Mutation: {
-	  addRssFeed: async (_, { url, userID }, { db, req, res }) => {
-		// await authMiddleware(req, res, () => {});
-  
-		// const decodedToken = JSON.parse(req.headers.user as string);
-		// if (!decodedToken) {
-		//   throw new Error('Unauthorized');
-		// }
-  
-		// if (decodedToken.sub !== userID) {
-		//   throw new Error('Forbidden');
-		// }
-  
-		const rss_data = db.collection("rss_links");
-  
-		// Create or update the RSS feed for the given userID
-		const filter = { userID: userID };
-		const update = {
-		  $set: { url: url, userID: userID },
-		};
-		const options = {
-		  upsert: true, // create a new document if no document matches the filter
-		  returnDocument: "after", // return the modified document
-		};
-  
-		const result = await rss_data.findOneAndUpdate(filter, update, options);
+  Mutation: {
+    addRssFeed: async (_, { url, userID }, { db, req, res }) => {
+      const decodedToken = getUserFromHeaders(req);
 
-    return result.value;
-	  },
-	},
-  Query: {
-    // RSS Resolver
-    getRssLinkByUserId: async (_, args, { db, req, res }) => {
-      // // await authMiddleware(req, res, () => {});
-
-      // const userHeader = req.headers.user;
-      // if (!userHeader) {
-      //   throw new Error('Unauthorized');
-      // }
-
-      // const decodedToken = JSON.parse(userHeader as string);
-      // if (!decodedToken) {
-      //   throw new Error('Unauthorized');
-      // }
+      if (decodedToken.sub !== userID) {
+        throw new Error('Forbidden');
+      }
 
       const rss_data = db.collection("rss_links");
-      const queryResult = await rss_data.find({ userID: args.user_id }).toArray();
-      return queryResult;
+      const filter = { userID: userID };
+      const update = { $set: { url, userID } };
+      const options = { upsert: true, returnDocument: "after" };
+
+      const result = await rss_data.findOneAndUpdate(filter, update, options);
+      return result.value;
     },
-    // CSV Upload Resolver
-    getUploadByUserId: async (_, args, { db, req, res }) => {
-      // // await authMiddleware(req, res, () => {});
+  },
 
-      // const userHeader = req.headers.user;
-      // if (!userHeader) {
-      //   throw new Error('Unauthorized');
-      // }
+  Query: {
+    getRssLinkByUserId: async (_, args, { db, req }) => {
+      const decodedToken = getUserFromHeaders(req);
+      console.log(decodedToken);
+      const rss_data = db.collection("rss_links");
+      const queryResult = await rss_data.find({ userID: decodedToken.sub }).toArray();
+      return queryResult || [];
+    },
 
-      // const decodedToken = JSON.parse(userHeader as string);
-      // if (!decodedToken) {
-      //   throw new Error('Unauthorized');
-      // }
+    getUploadByUserId: async (_, args, { db, req }) => {
+      const decodedToken = getUserFromHeaders(req);
 
       const upload_data = db.collection("uploads");
-      const queryResult = await upload_data.find({ userID: args.user_id }).toArray();
-      return queryResult;
+      const queryResult = await upload_data.find({ userID: decodedToken.sub }).toArray();
+      return queryResult || [];
     },
-    // Topic Resolvers
-    getAllTopics: async (_, args, { db, req, res }): Promise<String[]> => {
-      // // await authMiddleware(req, res, () => {});
 
-      // const userHeader = req.headers.user;
-      // if (!userHeader) {
-      //   throw new Error('Unauthorized');
-      // }
-
-      // const decodedToken = JSON.parse(userHeader as string);
-      // if (!decodedToken) {
-      //   throw new Error('Unauthorized');
-      // }
+    getAllTopics: async (_, args, { db, req }) => {
+      const decodedToken = getUserFromHeaders(req);
 
       const articles_data = db.collection("articles_data");
-      const topics: string[] = await articles_data.distinct("position_section", { userID: args.userID });
-      return topics;
+      const topics = await articles_data.distinct("position_section", { userID: decodedToken.sub });
+      return topics || [];
     },
-    getAllLabels: async (_, args, { db, req, res }): Promise<String[]> => {
-      // // await authMiddleware(req, res, () => {});
 
-      // const userHeader = req.headers.user;
-      // if (!userHeader) {
-      //   throw new Error('Unauthorized');
-      // }
-
-      // const decodedToken = JSON.parse(userHeader as string);
-      // if (!decodedToken) {
-      //   throw new Error('Unauthorized');
-      // }
+    getAllLabels: async (_, args, { db, req }) => {
+      const decodedToken = getUserFromHeaders(req);
 
       const topic_data = db.collection("articles_data");
+      const topics = await topic_data.aggregate([
+        { $match: { userID: decodedToken.sub } },
+        { $unwind: "$openai_labels" },
+        { $group: { _id: null, unique_labels: { $addToSet: "$openai_labels" } } },
+      ]).toArray();
 
-      const topics = await topic_data
-        .aggregate([
-          {
-            $match: { userID: args.userID }, // Filters documents based on userID
-          },
-          {
-            $unwind: "$openai_labels", // Deconstructs the `openai_labels` array
-          },
-          {
-            $group: {
-              _id: null, // Groups all documents together (null means no grouping)
-              unique_labels: { $addToSet: "$openai_labels" }, // Creates a set of unique labels
-            },
-          },
-        ])
-        .toArray();
-
-      return topics[0].unique_labels;
+      return topics[0]?.unique_labels || [];
     },
-    // Tract Resolvers
-    demographicsByTracts: async (_, args: DemographicsByTractsArgs, { db, req, res }): Promise<ITracts[]> => {
-      // // await authMiddleware(req, res, () => {});
 
-      // const userHeader = req.headers.user;
-      // if (!userHeader) {
-      //   throw new Error('Unauthorized');
-      // }
-
-      // const decodedToken = JSON.parse(userHeader as string);
-      // if (!decodedToken) {
-      //   throw new Error('Unauthorized');
-      // }
+    demographicsByTracts: async (_, args: DemographicsByTractsArgs, { db, req }) => {
+      const decodedToken = getUserFromHeaders(req);
 
       const tracts_data: Collection<ITracts> = db.collection("tracts_data");
-
-      const queryResult: ITracts[] = await tracts_data
-        .find({
-          tract: args.tract,
-        })
-        .toArray();
+      const queryResult: ITracts[] = await tracts_data.find({ tract: args.tract, userID: decodedToken.sub }).toArray();
       if (queryResult.length === 0) {
-        const noDataTract: ITracts = {
+        return [{
           county_name: "",
           tract: args.tract,
           geoid_tract: "",
           neighborhood: "",
           demographics: null,
           articles: null,
-        };
-        return [noDataTract];
+        }];
       }
 
       return queryResult;
     },
-    // Neighborhood Resolvers
-    tractsByNeighborhood: async (_, args: TractsByNeighborhoodArgs, { db, req, res }): Promise<INeighborhoods[]> => {
-      // // await authMiddleware(req, res, () => {});
 
-      // const userHeader = req.headers.user;
-      // if (!userHeader) {
-      //   throw new Error('Unauthorized');
-      // }
-
-      // const decodedToken = JSON.parse(userHeader as string);
-      // if (!decodedToken) {
-      //   throw new Error('Unauthorized');
-      // }
+    tractsByNeighborhood: async (_, args: TractsByNeighborhoodArgs, { db, req }) => {
+      const decodedToken = getUserFromHeaders(req);
 
       const neighborhood_data: Collection<INeighborhoods> = db.collection("neighborhood_data");
-
-      const queryResult: INeighborhoods[] = await neighborhood_data
-        .find({
-          value: args.neighborhood,
-        })
-        .toArray();
-
-      return queryResult;
+      const queryResult = await neighborhood_data.find({ value: args.neighborhood, userID: decodedToken.sub }).toArray();
+      return queryResult || [];
     },
-    getAllNeighborhoods: async (_, __, { db, req, res }): Promise<INeighborhoods[]> => {
-      // // await authMiddleware(req, res, () => {});
 
-      // const userHeader = req.headers.user;
-      // if (!userHeader) {
-      //   throw new Error('Unauthorized');
-      // }
-
-      // const decodedToken = JSON.parse(userHeader as string);
-      // if (!decodedToken) {
-      //   throw new Error('Unauthorized');
-      // }
+    getAllNeighborhoods: async (_, __, { db, req }) => {
+      const decodedToken = getUserFromHeaders(req);
 
       const neighborhood_data: Collection<INeighborhoods> = db.collection("neighborhood_data");
-      const neighborhoods: INeighborhoods[] = await neighborhood_data.find({}).toArray();
-      return neighborhoods;
+      const neighborhoods = await neighborhood_data.find({userID: decodedToken.sub}).toArray();
+      return neighborhoods || [];
     },
-    // Article Resolvers
-    articleByDate: async (_, args, { db, req, res }): Promise<IArticles[]> => {
-      // // await authMiddleware(req, res, () => {});
 
-      // const userHeader = req.headers.user;
-      // if (!userHeader) {
-      //   throw new Error('Unauthorized');
-      // }
-
-      // const decodedToken = JSON.parse(userHeader as string);
-      // if (!decodedToken) {
-      //   throw new Error('Unauthorized');
-      // }
+    articleByDate: async (_, args, { db, req }) => {
+      const decodedToken = getUserFromHeaders(req);
 
       const articles_data = db.collection("articles_data");
 
+      const query = {
+        dateSum: { $gte: args.dateFrom, $lte: args.dateTo },
+        userID: decodedToken.sub,
+      };
+
       if (isNumber(args.area)) {
-        const queryResult = await articles_data
-          .find({
-            dateSum: {
-              $gte: args.dateFrom,
-              $lte: args.dateTo,
-            },
-            tracts: args.area,
-            userID: args.userID,
-          })
-          .toArray();
-
-        return queryResult;
-      } else if (args.area === "all") {
-        const queryResult = await articles_data
-          .find({
-            dateSum: {
-              $gte: args.dateFrom,
-              $lte: args.dateTo,
-            },
-            userID: args.userID,
-          })
-          .toArray();
-
-        return queryResult;
-      } else {
-        const queryResult = await articles_data
-          .find({
-            dateSum: {
-              $gte: args.dateFrom,
-              $lte: args.dateTo,
-            },
-            neighborhoods: args.area,
-            userID: args.userID,
-          })
-          .toArray();
-
-        return queryResult;
+        query["tracts"] = args.area;
+      } else if (args.area !== "all") {
+        query["neighborhoods"] = args.area;
       }
+
+      const queryResult = await articles_data.find(query).toArray();
+      return queryResult || [];
     },
 
-    orgArticlesPastWeek: async (_, args, { db, req, res }): Promise<IArticles[]> => {
-      // // await authMiddleware(req, res, () => {});
-
-      // const userHeader = req.headers.user;
-      // if (!userHeader) {
-      //   throw new Error('Unauthorized');
-      // }
-
-      // const decodedToken = JSON.parse(userHeader as string);
-      // if (!decodedToken) {
-      //   throw new Error('Unauthorized');
-      // }
+    orgArticlesPastWeek: async (_, args, { db, req }) => {
+      const decodedToken = getUserFromHeaders(req);
 
       const articles_data = db.collection("articles_data");
       const today = new Date();
-      var querydate = new Date(today);
+      const querydate = new Date(today);
       querydate.setDate(today.getDate() - 7);
 
       const todaydate = Number(today.toISOString().split("T")[0].split("-").join(""));
       const sevendays = Number(querydate.toISOString().split("T")[0].split("-").join(""));
-      const queryResult = await articles_data
-        .find({
-          dateSum: {
-            $gte: sevendays,
-            $lte: todaydate,
-          },
-          userID: args.userID,
-        })
-        .toArray();
 
-      return queryResult;
+      const queryResult = await articles_data.find({
+        dateSum: { $gte: sevendays, $lte: todaydate },
+        userID: decodedToken.sub,
+      }).toArray();
+
+      return queryResult || [];
     },
 
-    articleByTopicsOrLabels: async (_, args, { db, req, res }): Promise<IArticles[]> => {
-      // // await authMiddleware(req, res, () => {});
-
-      // const userHeader = req.headers.user;
-      // if (!userHeader) {
-      //   throw new Error('Unauthorized');
-      // }
-
-      // const decodedToken = JSON.parse(userHeader as string);
-      // if (!decodedToken) {
-      //   throw new Error('Unauthorized');
-      // }
+    articleByTopicsOrLabels: async (_, args, { db, req }) => {
+      const decodedToken = getUserFromHeaders(req);
 
       const articles_data = db.collection("articles_data");
+      const query = {
+        dateSum: { $gte: args.dateFrom, $lte: args.dateTo },
+        userID: decodedToken.sub,
+        $or: [
+          { openai_labels: { $in: [args.labelOrTopic] } },
+          { position_section: { $regex: args.labelOrTopic, $options: "i" } },
+        ],
+      };
 
       if (isNumber(args.area)) {
-        const queryResult = await articles_data
-          .find({
-            dateSum: {
-              $gte: args.dateFrom,
-              $lte: args.dateTo,
-            },
-            userID: args.userID,
-            tracts: args.area,
-            $or: [
-              { openai_labels: { $in: [args.labelOrTopic] } },
-              {
-                position_section: {
-                  $regex: args.labelOrTopic,
-                  $options: "i",
-                },
-              },
-            ],
-          })
-          .toArray();
-
-        return queryResult;
-      } else if (args.area === "all") {
-        const queryResult = await articles_data
-          .find({
-            dateSum: {
-              $gte: args.dateFrom,
-              $lte: args.dateTo,
-            },
-            userID: args.userID,
-            $or: [
-              { openai_labels: { $in: [args.labelOrTopic] } },
-              {
-                position_section: {
-                  $regex: args.labelOrTopic,
-                  $options: "i",
-                },
-              },
-            ],
-          })
-          .toArray();
-
-        return queryResult;
-      } else {
-        const queryResult = await articles_data
-          .find({
-            dateSum: {
-              $gte: args.dateFrom,
-              $lte: args.dateTo,
-            },
-            userID: args.userID,
-            neighborhoods: args.area,
-            $or: [
-              { openai_labels: { $in: [args.labelOrTopic] } },
-              {
-                position_section: {
-                  $regex: args.labelOrTopic,
-                  $options: "i",
-                },
-              },
-            ],
-          })
-          .toArray();
-
-        return queryResult;
+        query["tracts"] = args.area;
+      } else if (args.area !== "all") {
+        query["neighborhoods"] = args.area;
       }
+
+      const queryResult = await articles_data.find(query).toArray();
+      return queryResult || [];
     },
-    getAllArticles: async (_, __, { db, req, res }): Promise<IArticles[]> => {
-      // // await authMiddleware(req, res, () => {});
 
-      // const userHeader = req.headers.user;
-      // if (!userHeader) {
-      //   throw new Error('Unauthorized');
-      // }
-
-      // const decodedToken = JSON.parse(userHeader as string);
-      // if (!decodedToken) {
-      //   throw new Error('Unauthorized');
-      // }
+    getAllArticles: async (_, __, { db, req }) => {
+      const decodedToken = getUserFromHeaders(req);
 
       const article_data: Collection<IArticles> = db.collection("articles_data");
-      const articles: IArticles[] = await article_data.find({}).toArray();
-      return articles;
+      const articles = await article_data.find({userID: decodedToken.sub}).toArray();
+      return articles || [];
     },
-    getArticlesByOrg: async (_, args, { db, req, res }): Promise<IArticles[]> => {
-      // // await authMiddleware(req, res, () => {});
 
-      // const userHeader = req.headers.user;
-      // if (!userHeader) {
-      //   throw new Error('Unauthorized');
-      // }
-
-      // const decodedToken = JSON.parse(userHeader as string);
-      // if (!decodedToken) {
-      //   throw new Error('Unauthorized');
-      // }
+    getArticlesByOrg: async (_, args, { db, req }) => {
+      const decodedToken = getUserFromHeaders(req);
 
       const article_data: Collection<IArticles> = db.collection("articles_data");
-      const articles: IArticles[] = await article_data.find({ userID: args.userID }).toArray();
-      return articles;
+      const articles = await article_data.find({ userID: decodedToken.sub}).toArray();
+      return articles || [];
     },
-    // Location Resolvers
-    getAllLocations: async (_, __, { db, req, res }): Promise<ILocations[]> => {
-      // // await authMiddleware(req, res, () => {});
 
-      // const userHeader = req.headers.user;
-      // if (!userHeader) {
-      //   throw new Error('Unauthorized');
-      // }
+    getAllLocations: async (_, __, { db, req }) => {
+      const decodedToken = getUserFromHeaders(req);
 
-      // const decodedToken = JSON.parse(userHeader as string);
-      // if (!decodedToken) {
-      //   throw new Error('Unauthorized');
-      // }
-      try {
-        const location_data: Collection<ILocations> = db.collection("locations_data");
-        const locations: ILocations[] = await location_data.find({}).toArray();
-        return locations;
-      } catch (error) {
-        console.log(error);
-      } 
-    }
+      const location_data: Collection<ILocations> = db.collection("locations_data");
+      const locations = await location_data.find({userID: decodedToken.sub}).toArray();
+      return locations || [];
+    },
   },
 };


### PR DESCRIPTION
Goal: Improve security and get the graph ql resolvers working again

- Global Clerk authentication middleware (`clerkMiddleware()`) for user verification via JWT, so no more manual auth middleware
- Helper function `getUserFromHeaders` decodes the JWT from request headers to verify the user in each resolver, helps readability and decreases LOC
- The `userID` from decoded JWT  ensures that each request is tied to the authenticated user
- Eliminates the need for manually parsing the JWT in each resolver
- Using `decodedToken.sub` for filtering data specific to the authenticated user, rather than the old code using `args.userID `directly
- verifying the JWT on every request
- separating middleware and JWT verification logic from resolver logic
